### PR TITLE
Add language field to logging and local dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
    },
    "scripts": {
       "build": "tsc",
+      "dev": "LOCAL=true node dist/dev-server.js",
       "deploy": "run-s deploy:log-feature-click deploy:log-geocode",
       "deploy:log-feature-click": "gcloud functions deploy log-feature-click --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20",
       "deploy:log-geocode": "gcloud functions deploy log-geocode --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20",

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -1,0 +1,60 @@
+import http from 'http';
+import {logFeatureClick} from './log-feature-click';
+import {logGeocode} from './log-geocode';
+
+const PORT = 8080;
+
+const routes: Record<string, Function> = {
+  '/log-feature-click': logFeatureClick,
+  '/log-geocode': logGeocode,
+};
+
+const server = http.createServer((req, res) => {
+  const url = req.url || '';
+
+  // CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const handler = routes[url];
+  if (!handler) {
+    res.writeHead(404);
+    res.end('Not found');
+    return;
+  }
+
+  // Parse JSON body
+  let body = '';
+  req.on('data', (chunk) => { body += chunk; });
+  req.on('end', () => {
+    const mockReq = {
+      method: req.method,
+      headers: req.headers,
+      body: body ? JSON.parse(body) : {},
+      connection: req.connection,
+    };
+    const mockRes = {
+      set: (key: string, value: string) => res.setHeader(key, value),
+      status: (code: number) => ({
+        send: (msg: string) => {
+          res.writeHead(code);
+          res.end(msg);
+        },
+      }),
+    };
+    handler(mockReq, mockRes);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Dev server running at http://localhost:${PORT}`);
+  console.log('Routes: /log-feature-click, /log-geocode');
+  console.log('BigQuery calls are stubbed (LOCAL=true)');
+});

--- a/src/log-feature-click.ts
+++ b/src/log-feature-click.ts
@@ -1,6 +1,8 @@
 import {HttpFunction} from '@google-cloud/functions-framework';
 import {BigQuery} from '@google-cloud/bigquery';
 
+const LOCAL = process.env.LOCAL === 'true';
+
 export const logFeatureClick: HttpFunction = async (req, res) => {
   res.set('Access-Control-Allow-Origin', "*")
   res.set('Access-Control-Allow-Methods', 'GET, POST');
@@ -9,21 +11,27 @@ export const logFeatureClick: HttpFunction = async (req, res) => {
     res.status(204).send('');
   }else{
     const ipAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    const bigquery = new BigQuery();
-    try{
-      await bigquery
-      .dataset('resourceMap')
-      .table('featureClicks')
-      .insert({
-	featureId: req.body.id,
-	ipAddress,
-	lat: parseFloat(req.body.lat.toFixed(8)),
-	lng: parseFloat(req.body.lng.toFixed(8)),
-	timestamp: new Date(),
-      });
-    }catch(error){
-      // @ts-ignore
-      console.log(error);
+    const row = {
+      featureId: req.body.id,
+      ipAddress,
+      lat: parseFloat(req.body.lat.toFixed(8)),
+      lng: parseFloat(req.body.lng.toFixed(8)),
+      language: req.body.language || 'en',
+      timestamp: new Date(),
+    };
+    if(LOCAL){
+      console.log('[LOCAL] featureClicks:', row);
+    }else{
+      const bigquery = new BigQuery();
+      try{
+        await bigquery
+        .dataset('resourceMap')
+        .table('featureClicks')
+        .insert(row);
+      }catch(error){
+        // @ts-ignore
+        console.log(error);
+      }
     }
     res.status(200).send('OK');
   }

--- a/src/log-geocode.ts
+++ b/src/log-geocode.ts
@@ -1,6 +1,8 @@
 import {HttpFunction} from '@google-cloud/functions-framework';
 import {BigQuery} from '@google-cloud/bigquery';
 
+const LOCAL = process.env.LOCAL === 'true';
+
 export const logGeocode: HttpFunction = async (req, res) => {
   res.set('Access-Control-Allow-Origin', "*")
   res.set('Access-Control-Allow-Methods', 'GET, POST');
@@ -8,23 +10,28 @@ export const logGeocode: HttpFunction = async (req, res) => {
   if(req.method === 'OPTIONS'){
     res.status(204).send('');
   }else{
-
     const ipAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    const bigquery = new BigQuery();
-    try{
-      await bigquery
-      .dataset('resourceMap')
-      .table('geocodes')
-      .insert({
-	address: req.body.address,
-	ipAddress,
-	lat: parseFloat(req.body.lat.toFixed(8)),
-	lng: parseFloat(req.body.lng.toFixed(8)),
-	timestamp: new Date(),
-      });
-    }catch(error){
-      // @ts-ignore
-      console.log(error.errors[0]);
+    const row = {
+      address: req.body.address,
+      ipAddress,
+      lat: parseFloat(req.body.lat.toFixed(8)),
+      lng: parseFloat(req.body.lng.toFixed(8)),
+      language: req.body.language || 'en',
+      timestamp: new Date(),
+    };
+    if(LOCAL){
+      console.log('[LOCAL] geocodes:', row);
+    }else{
+      const bigquery = new BigQuery();
+      try{
+        await bigquery
+        .dataset('resourceMap')
+        .table('geocodes')
+        .insert(row);
+      }catch(error){
+        // @ts-ignore
+        console.log(error.errors[0]);
+      }
     }
     res.status(200).send('OK');
   }


### PR DESCRIPTION
## Summary
- Add `language` field to both `log-feature-click` and `log-geocode` BigQuery inserts (defaults to `en` for backwards compatibility)
- Add `LOCAL=true` environment mode that console logs payloads instead of writing to BigQuery
- Add `dev-server.ts` — lightweight HTTP server that serves both functions on port 8080 for local development
- Add `yarn dev` script (`LOCAL=true node dist/dev-server.js`)

## Required: BigQuery schema update
Run these in BigQuery before deploying:
```sql
ALTER TABLE resourceMap.featureClicks ADD COLUMN language STRING;
ALTER TABLE resourceMap.geocodes ADD COLUMN language STRING;
```

## Test plan
- [ ] `yarn build && yarn dev` starts local server on port 8080
- [ ] POST to `/log-feature-click` logs payload to console with `[LOCAL]` prefix
- [ ] POST to `/log-geocode` logs payload to console with `[LOCAL]` prefix
- [ ] Language field defaults to `en` when not provided
- [ ] After BigQuery schema update, deploy and verify language is recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)