### PR TITLE
Privacy refresh: drop raw IP, split search text, add geo enrichment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
    "author": "Jon Chin <jon@shareneaks.org>",
    "license": "MIT",
    "devDependencies": {
+      "@types/geoip-lite": "^1.4.4",
       "npm-run-all": "^4.1.5",
       "typescript": "^5.4.2"
    },
@@ -20,7 +21,8 @@
    },
    "dependencies": {
       "@google-cloud/bigquery": "^7.9.3",
-      "@google-cloud/functions-framework": "^3.5.1"
+      "@google-cloud/functions-framework": "^3.5.1",
+      "geoip-lite": "1.4.10"
    },
    "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/schema/2026-07-privacy-refresh.sql
+++ b/schema/2026-07-privacy-refresh.sql
@@ -1,0 +1,51 @@
+-- BigQuery migration for the privacy refresh.
+-- Run against the `resourceMap` dataset.
+--
+-- Deploy order:
+--   1. Run this file (adds columns + creates the new table).
+--   2. Deploy the new Cloud Function code — it starts writing to the
+--      new columns and to the searches table. Legacy columns
+--      (address, ipAddress) are left untouched; new rows have NULL there.
+--   3. Confirm new rows look right, no `console.error` alerts firing.
+--   4. Optionally: drop the legacy columns once you're sure. (Commented
+--      out below.)
+--
+-- No rows are altered by this file. Legacy data preserved for archive.
+
+-- geocodes: add osFamily, IP-derived location, and Google's location_type.
+ALTER TABLE `resourceMap.geocodes`
+  ADD COLUMN IF NOT EXISTS osFamily      STRING,
+  ADD COLUMN IF NOT EXISTS city          STRING,
+  ADD COLUMN IF NOT EXISTS region        STRING,
+  ADD COLUMN IF NOT EXISTS country       STRING,
+  ADD COLUMN IF NOT EXISTS locationType  STRING;
+
+-- featureClicks: same enrichment (no locationType — pantry data is public).
+ALTER TABLE `resourceMap.featureClicks`
+  ADD COLUMN IF NOT EXISTS osFamily  STRING,
+  ADD COLUMN IF NOT EXISTS city      STRING,
+  ADD COLUMN IF NOT EXISTS region    STRING,
+  ADD COLUMN IF NOT EXISTS country   STRING;
+
+-- searches: new table. Sparse by design — no sessionId, no coord,
+-- no raw text. Populated on every /log-geocode call including zero-result
+-- searches (where searchType = 'unknown' and resultBucket = 'NONE').
+CREATE TABLE IF NOT EXISTS `resourceMap.searches` (
+  searchType        STRING    NOT NULL,
+  resultBucket      STRING    NOT NULL,   -- 'NONE' | 'UNIQUE' | 'AMBIGUOUS'
+  resolvedCity      STRING,
+  resolvedRegion    STRING,
+  resolvedBorough   STRING,
+  resolvedCountry   STRING,
+  language          STRING    NOT NULL,
+  osFamily          STRING,
+  country           STRING,                -- derived from client IP
+  timestamp         TIMESTAMP NOT NULL
+);
+
+-- Optional cleanup step (run AFTER verifying new code writes correctly
+-- and you're ready to stop retaining raw address / IP in these tables).
+-- Uncomment when ready:
+--
+-- ALTER TABLE `resourceMap.geocodes`       DROP COLUMN IF EXISTS address, DROP COLUMN IF EXISTS ipAddress;
+-- ALTER TABLE `resourceMap.featureClicks`  DROP COLUMN IF EXISTS ipAddress;

--- a/src/geo.ts
+++ b/src/geo.ts
@@ -1,0 +1,33 @@
+import geoip from 'geoip-lite';
+
+export interface GeoInfo {
+  city: string | null;
+  region: string | null;
+  country: string | null;
+}
+
+const EMPTY: GeoInfo = {city: null, region: null, country: null};
+
+// Normalize the potentially-multi-hop x-forwarded-for header down to
+// the original client IP. When a request is proxied (Cloud Load Balancer
+// in front of Cloud Functions), x-forwarded-for is a comma-separated
+// list with the client's IP as the first entry.
+function extractClientIp(raw: string | string[] | undefined): string | null {
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  if (!first) return null;
+  return first.split(',')[0].trim() || null;
+}
+
+// Look up city/region/country from an IP. Never surfaces the IP itself.
+// Returns nulls when the IP is missing, private, or not in the DB.
+export function lookupGeo(rawForwardedFor: string | string[] | undefined): GeoInfo {
+  const ip = extractClientIp(rawForwardedFor);
+  if (!ip) return EMPTY;
+  const g = geoip.lookup(ip);
+  if (!g) return EMPTY;
+  return {
+    city: g.city || null,
+    region: g.region || null,
+    country: g.country || null,
+  };
+}

--- a/src/log-feature-click.ts
+++ b/src/log-feature-click.ts
@@ -17,6 +17,7 @@ export const logFeatureClick: HttpFunction = async (req, res) => {
       lat: parseFloat(req.body.lat.toFixed(8)),
       lng: parseFloat(req.body.lng.toFixed(8)),
       language: req.body.language || 'en',
+      sessionId: req.body.sessionId || null,
       timestamp: new Date(),
     };
     if(LOCAL){

--- a/src/log-feature-click.ts
+++ b/src/log-feature-click.ts
@@ -1,39 +1,60 @@
 import {HttpFunction} from '@google-cloud/functions-framework';
 import {BigQuery} from '@google-cloud/bigquery';
+import {lookupGeo} from './geo';
 
 const LOCAL = process.env.LOCAL === 'true';
 
+interface FeatureClickRow {
+  featureId: string | null;
+  sessionId: string | null;
+  lat: number | null;
+  lng: number | null;
+  language: string;
+  osFamily: string | null;
+  city: string | null;
+  region: string | null;
+  country: string | null;
+  timestamp: Date;
+}
+
 export const logFeatureClick: HttpFunction = async (req, res) => {
-  res.set('Access-Control-Allow-Origin', "*")
+  res.set('Access-Control-Allow-Origin', '*');
   res.set('Access-Control-Allow-Methods', 'GET, POST');
   res.set('Access-Control-Allow-Headers', 'Content-Type');
-  if(req.method === 'OPTIONS'){
+  if (req.method === 'OPTIONS') {
     res.status(204).send('');
-  }else{
-    const ipAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    const row = {
-      featureId: req.body.id,
-      ipAddress,
-      lat: parseFloat(req.body.lat.toFixed(8)),
-      lng: parseFloat(req.body.lng.toFixed(8)),
-      language: req.body.language || 'en',
-      sessionId: req.body.sessionId || null,
-      timestamp: new Date(),
-    };
-    if(LOCAL){
-      console.log('[LOCAL] featureClicks:', row);
-    }else{
-      const bigquery = new BigQuery();
-      try{
-        await bigquery
-        .dataset('resourceMap')
-        .table('featureClicks')
-        .insert(row);
-      }catch(error){
-        // @ts-ignore
-        console.log(error);
-      }
-    }
-    res.status(200).send('OK');
+    return;
   }
+
+  const b = req.body || {};
+  const geo = lookupGeo(req.headers['x-forwarded-for']);
+
+  const row: FeatureClickRow = {
+    featureId: b.id != null ? String(b.id) : null,
+    sessionId: b.sessionId || null,
+    // Full-precision — these are pantry locations, already public map data.
+    lat: typeof b.lat === 'number' && isFinite(b.lat) ? parseFloat(b.lat.toFixed(8)) : null,
+    lng: typeof b.lng === 'number' && isFinite(b.lng) ? parseFloat(b.lng.toFixed(8)) : null,
+    language: b.language || 'en',
+    osFamily: b.osFamily || null,
+    city: geo.city,
+    region: geo.region,
+    country: geo.country,
+    timestamp: new Date(),
+  };
+
+  if (LOCAL) {
+    console.log('[LOCAL] featureClicks:', row);
+    res.status(200).send('OK');
+    return;
+  }
+
+  try {
+    const bigquery = new BigQuery();
+    await bigquery.dataset('resourceMap').table('featureClicks').insert(row);
+  } catch (err: any) {
+    console.error('[log-feature-click] BigQuery insert to "featureClicks" failed:', err?.errors?.[0] || err);
+  }
+
+  res.status(200).send('OK');
 };

--- a/src/log-geocode.ts
+++ b/src/log-geocode.ts
@@ -17,6 +17,7 @@ export const logGeocode: HttpFunction = async (req, res) => {
       lat: parseFloat(req.body.lat.toFixed(8)),
       lng: parseFloat(req.body.lng.toFixed(8)),
       language: req.body.language || 'en',
+      sessionId: req.body.sessionId || null,
       timestamp: new Date(),
     };
     if(LOCAL){

--- a/src/log-geocode.ts
+++ b/src/log-geocode.ts
@@ -1,39 +1,125 @@
 import {HttpFunction} from '@google-cloud/functions-framework';
 import {BigQuery} from '@google-cloud/bigquery';
+import {lookupGeo} from './geo';
 
 const LOCAL = process.env.LOCAL === 'true';
+const DATASET = 'resourceMap';
+
+// Truncate coord to a ~110m grid so we never persist a home-precise
+// location for a user's search.
+function truncateCoord(n: number | null | undefined): number | null {
+  if (typeof n !== 'number' || !isFinite(n)) return null;
+  return Math.round(n * 1000) / 1000;
+}
+
+// Rows never carry the raw IP, the typed search text, or any join key
+// linking the geocodes row to the searches row.
+
+interface GeocodeRow {
+  sessionId: string | null;
+  lat: number | null;
+  lng: number | null;
+  language: string;
+  osFamily: string | null;
+  city: string | null;
+  region: string | null;
+  country: string | null;
+  locationType: string | null;
+  timestamp: Date;
+}
+
+interface SearchRow {
+  searchType: string;
+  resultBucket: 'NONE' | 'UNIQUE' | 'AMBIGUOUS';
+  resolvedCity: string | null;
+  resolvedRegion: string | null;
+  resolvedBorough: string | null;
+  resolvedCountry: string | null;
+  language: string;
+  osFamily: string | null;
+  country: string | null;
+  timestamp: Date;
+}
 
 export const logGeocode: HttpFunction = async (req, res) => {
-  res.set('Access-Control-Allow-Origin', "*")
+  res.set('Access-Control-Allow-Origin', '*');
   res.set('Access-Control-Allow-Methods', 'GET, POST');
   res.set('Access-Control-Allow-Headers', 'Content-Type');
-  if(req.method === 'OPTIONS'){
+  if (req.method === 'OPTIONS') {
     res.status(204).send('');
-  }else{
-    const ipAddress = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
-    const row = {
-      address: req.body.address,
-      ipAddress,
-      lat: parseFloat(req.body.lat.toFixed(8)),
-      lng: parseFloat(req.body.lng.toFixed(8)),
-      language: req.body.language || 'en',
-      sessionId: req.body.sessionId || null,
-      timestamp: new Date(),
+    return;
+  }
+
+  const b = req.body || {};
+  const geo = lookupGeo(req.headers['x-forwarded-for']);
+  const language = b.language || 'en';
+  const osFamily = b.osFamily || null;
+  const timestamp = new Date();
+
+  const searchRow: SearchRow = {
+    searchType: typeof b.searchType === 'string' ? b.searchType : 'unknown',
+    resultBucket: normalizeResultBucket(b.resultBucket),
+    resolvedCity: b.resolvedCity || null,
+    resolvedRegion: b.resolvedRegion || null,
+    resolvedBorough: b.resolvedBorough || null,
+    resolvedCountry: b.resolvedCountry || null,
+    language,
+    osFamily,
+    country: geo.country,
+    timestamp,
+  };
+
+  const rowsToInsert: Array<{table: string; row: GeocodeRow | SearchRow}> = [
+    {table: 'searches', row: searchRow},
+  ];
+
+  // Zero-result searches skip the geocodes table (there's no coord to log).
+  if (b.resultsFound !== false && typeof b.lat === 'number' && typeof b.lng === 'number') {
+    const geocodeRow: GeocodeRow = {
+      sessionId: b.sessionId || null,
+      lat: truncateCoord(b.lat),
+      lng: truncateCoord(b.lng),
+      language,
+      osFamily,
+      city: geo.city,
+      region: geo.region,
+      country: geo.country,
+      locationType: b.resolvedLocationType || null,
+      timestamp,
     };
-    if(LOCAL){
-      console.log('[LOCAL] geocodes:', row);
-    }else{
-      const bigquery = new BigQuery();
-      try{
-        await bigquery
-        .dataset('resourceMap')
-        .table('geocodes')
-        .insert(row);
-      }catch(error){
-        // @ts-ignore
-        console.log(error.errors[0]);
-      }
+    rowsToInsert.push({table: 'geocodes', row: geocodeRow});
+  }
+
+  if (LOCAL) {
+    for (const {table, row} of rowsToInsert) {
+      console.log(`[LOCAL] ${table}:`, row);
     }
     res.status(200).send('OK');
+    return;
   }
+
+  const bigquery = new BigQuery();
+  const ds = bigquery.dataset(DATASET);
+  const inserts = await Promise.allSettled(
+    rowsToInsert.map(({table, row}) => ds.table(table).insert(row))
+  );
+
+  for (let i = 0; i < inserts.length; i++) {
+    const outcome = inserts[i];
+    if (outcome.status === 'rejected') {
+      // console.error so Cloud Logging picks these up at severity ERROR.
+      // A log-based metric + alert policy on this will page us on real
+      // insert failures.
+      const table = rowsToInsert[i].table;
+      const err: any = outcome.reason;
+      console.error(`[log-geocode] BigQuery insert to "${table}" failed:`, err?.errors?.[0] || err);
+    }
+  }
+
+  res.status(200).send('OK');
 };
+
+function normalizeResultBucket(v: unknown): 'NONE' | 'UNIQUE' | 'AMBIGUOUS' {
+  if (v === 'NONE' || v === 'UNIQUE' || v === 'AMBIGUOUS') return v;
+  return 'NONE';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/geoip-lite@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@types/geoip-lite/-/geoip-lite-1.4.4.tgz#6573056a23129f25dcf9d53ca36bc3770192f109"
+  integrity sha512-2uVfn+C6bX/H356H6mjxsWUA5u8LO8dJgSBIRO/NFlpMe4DESzacutD/rKYrTDKm1Ugv78b4Wz1KvpHrlv3jSw==
+
 "@types/http-errors@*":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
@@ -243,6 +248,13 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 array-buffer-byte-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz#1e5583ec16763540a27ae52eed99ff899223568f"
@@ -274,6 +286,13 @@ arrify@^2.0.0, arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+"async@2.1 - 2.6.4":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -333,6 +352,11 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -380,6 +404,14 @@ call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
+"chalk@4.1 - 4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -408,10 +440,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -765,6 +809,13 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
+  dependencies:
+    pend "~1.2.0"
+
 finalhandler@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.3.1.tgz#0c575f1d1d324ddd1da35ad7ece3df7d19088019"
@@ -821,6 +872,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -860,6 +916,19 @@ gcp-metadata@^6.1.0:
     gaxios "^6.1.1"
     google-logging-utils "^0.0.2"
     json-bigint "^1.0.0"
+
+geoip-lite@1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/geoip-lite/-/geoip-lite-1.4.10.tgz#138256ba97f1abee1afdec78df97a78d320c50f6"
+  integrity sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==
+  dependencies:
+    async "2.1 - 2.6.4"
+    chalk "4.1 - 4.1.2"
+    iconv-lite "0.4.13 - 0.6.3"
+    ip-address "5.8.9 - 5.9.4"
+    lazy "1.0.11"
+    rimraf "2.5.2 - 2.7.1"
+    yauzl "2.9.2 - 2.10.0"
 
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
@@ -904,6 +973,18 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 globalthis@^1.0.3:
   version "1.0.4"
@@ -964,6 +1045,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
   version "1.0.2"
@@ -1047,6 +1133,13 @@ https-proxy-agent@^7.0.1:
     agent-base "^7.1.2"
     debug "4"
 
+"iconv-lite@0.4.13 - 0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1054,7 +1147,15 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-inherits@2.0.4, inherits@^2.0.3:
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.4, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1067,6 +1168,15 @@ internal-slot@^1.0.7:
     es-errors "^1.3.0"
     hasown "^2.0.0"
     side-channel "^1.0.4"
+
+"ip-address@5.8.9 - 5.9.4":
+  version "5.9.4"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.9.4.tgz#4660ac261ad61bd397a860a007f7e98e4eaee386"
+  integrity sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==
+  dependencies:
+    jsbn "1.1.0"
+    lodash "^4.17.15"
+    sprintf-js "1.1.2"
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -1242,6 +1352,11 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
+
 json-bigint@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
@@ -1281,6 +1396,11 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
+lazy@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/lazy/-/lazy-1.0.11.tgz#daa068206282542c088288e975c297c1ae77b690"
+  integrity sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -1302,6 +1422,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash@^4.17.14, lodash@^4.17.15:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -1349,6 +1474,13 @@ minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -1441,7 +1573,7 @@ on-finished@2.4.1, on-finished@^2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.4.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1495,6 +1627,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
 path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -1516,6 +1653,11 @@ path-type@^3.0.0:
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 picocolors@^1.0.0:
   version "1.1.1"
@@ -1642,6 +1784,13 @@ retry-request@^7.0.0:
     extend "^3.0.2"
     teeny-request "^9.0.0"
 
+"rimraf@2.5.2 - 2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 safe-array-concat@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.2.tgz#81d77ee0c4e8b863635227c721278dd524c20edb"
@@ -1675,7 +1824,7 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -1839,6 +1988,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
   integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
 
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -1917,6 +2071,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -2134,3 +2295,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+"yauzl@2.9.2 - 2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"


### PR DESCRIPTION
## Summary
Reworks the two Cloud Functions (`log-geocode`, `log-feature-click`) to match what the CH Map's updated privacy policy promises. Companion to [share-meals/city-harvest-resource-map#43](https://github.com/share-meals/city-harvest-resource-map/pull/43), which stops sending raw address text and starts sending the classified fields.

## What changes

### `log-geocode` splits into two rows

Every call writes:

- **`geocodes`** — `sessionId`, `lat`/`lng` truncated to 3 decimals (~110m), `language`, `osFamily`, `city`/`region`/`country` (IP-derived), `locationType` (Google's precision hint), `timestamp`
- **`searches`** — no `sessionId`, no coord, no raw text. Only the classification the client derived from Google's response: `searchType`, `resultBucket`, `resolvedCity/Region/Borough/Country`. Enriched with `language`, `osFamily`, `country` (IP-derived), `timestamp`.

Zero-result searches (client sends `resultsFound: false`) skip the `geocodes` table entirely; only the `searches` row is written.

### `log-feature-click`
- Drops `ipAddress`
- Adds `osFamily` + IP-derived `city`/`region`/`country`
- Feature coords stay full precision (pantry locations are already public)

### GeoIP
- New `src/geo.ts` uses `geoip-lite@1.4.10` offline lookup. Raw IP never persisted or forwarded to any third party.
- Pinned to 1.4.10; 2.x requires Node 24 (Cloud Functions runtime is Node 20).

### Error logging
- BigQuery insert failures now hit `console.error` (were silent).
- Ready for a Cloud Logging alert policy on `severity>=ERROR AND resource.type=\"cloud_function\"`.

## Deploy sequence
1. Run `schema/2026-07-privacy-refresh.sql` against the `resourceMap` dataset (adds columns to existing tables; creates the new `searches` table; does not drop anything).
2. \`yarn deploy\`
3. Verify new rows land correctly.
4. Set up the Cloud Logging alert policy.
5. **(Later)** drop the legacy `address` and `ipAddress` columns once you're satisfied.

## Legacy data
Left in place. Existing rows keep their `address` and `ipAddress` values (per your call — archived for posterity). New rows have NULL in those columns until they're eventually dropped.

## Test plan
- [x] Local smoke test via `dev-server`: normal geocode, zero-result geocode, and feature click each land in the right stub tables with the right shape.
- [ ] After deploy: send one request of each shape from `curl`; check BigQuery streaming buffer has the expected rows.
- [ ] Confirm `console.error` output during a deliberately-broken insert shows up under Cloud Logging with severity ERROR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)