### PR TITLE
Add staging support: separate dataset + deploy scripts + schema fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
       "build": "tsc",
       "dev": "LOCAL=true node dist/dev-server.js",
       "deploy": "run-s deploy:log-feature-click deploy:log-geocode",
-      "deploy:log-feature-click": "gcloud functions deploy log-feature-click --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20",
-      "deploy:log-geocode": "gcloud functions deploy log-geocode --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20",
+      "deploy:log-feature-click": "gcloud functions deploy log-feature-click --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-feature-click",
+      "deploy:log-geocode": "gcloud functions deploy log-geocode --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-geocode",
+      "deploy:staging": "run-s deploy:staging:log-feature-click deploy:staging:log-geocode",
+      "deploy:staging:log-feature-click": "gcloud functions deploy log-feature-click-staging --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-feature-click --set-env-vars ENV=staging",
+      "deploy:staging:log-geocode": "gcloud functions deploy log-geocode-staging --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-geocode --set-env-vars ENV=staging",
       "prestart": "npm run build",
       "gcp-build": "npm run build"
    },

--- a/schema/2026-07-privacy-refresh.sql
+++ b/schema/2026-07-privacy-refresh.sql
@@ -1,7 +1,13 @@
 -- BigQuery migration for the privacy refresh.
--- Run against the `resourceMap` dataset.
 --
--- Deploy order:
+-- This file operates on the `resourceMap` dataset. Run it once against
+-- production, and once against `resourceMap_staging` (creating the
+-- staging dataset first if it does not yet exist).
+--
+-- Create the staging dataset with:
+--   bq --location=us mk --dataset city-harvest-423311:resourceMap_staging
+--
+-- Deploy order for either environment:
 --   1. Run this file (adds columns + creates the new table).
 --   2. Deploy the new Cloud Function code — it starts writing to the
 --      new columns and to the searches table. Legacy columns
@@ -11,21 +17,35 @@
 --      out below.)
 --
 -- No rows are altered by this file. Legacy data preserved for archive.
+--
+-- To apply to staging, edit `resourceMap` → `resourceMap_staging` in
+-- every reference below, or run each statement in the BQ console with
+-- the staging dataset selected.
 
--- geocodes: add osFamily, IP-derived location, and Google's location_type.
+-- geocodes: relax `address` (new code no longer sends it), add the
+-- session/language columns that were missing from the live schema (BigQuery
+-- has been silently dropping them from writes), and add the new enrichment.
 ALTER TABLE `resourceMap.geocodes`
+  ALTER COLUMN address DROP NOT NULL;
+
+ALTER TABLE `resourceMap.geocodes`
+  ADD COLUMN IF NOT EXISTS sessionId     STRING,
+  ADD COLUMN IF NOT EXISTS language      STRING,
   ADD COLUMN IF NOT EXISTS osFamily      STRING,
   ADD COLUMN IF NOT EXISTS city          STRING,
   ADD COLUMN IF NOT EXISTS region        STRING,
   ADD COLUMN IF NOT EXISTS country       STRING,
   ADD COLUMN IF NOT EXISTS locationType  STRING;
 
--- featureClicks: same enrichment (no locationType — pantry data is public).
+-- featureClicks: same missing columns + enrichment (no locationType — pantry
+-- data is public).
 ALTER TABLE `resourceMap.featureClicks`
-  ADD COLUMN IF NOT EXISTS osFamily  STRING,
-  ADD COLUMN IF NOT EXISTS city      STRING,
-  ADD COLUMN IF NOT EXISTS region    STRING,
-  ADD COLUMN IF NOT EXISTS country   STRING;
+  ADD COLUMN IF NOT EXISTS sessionId  STRING,
+  ADD COLUMN IF NOT EXISTS language   STRING,
+  ADD COLUMN IF NOT EXISTS osFamily   STRING,
+  ADD COLUMN IF NOT EXISTS city       STRING,
+  ADD COLUMN IF NOT EXISTS region     STRING,
+  ADD COLUMN IF NOT EXISTS country    STRING;
 
 -- searches: new table. Sparse by design — no sessionId, no coord,
 -- no raw text. Populated on every /log-geocode call including zero-result

--- a/src/log-feature-click.ts
+++ b/src/log-feature-click.ts
@@ -3,6 +3,9 @@ import {BigQuery} from '@google-cloud/bigquery';
 import {lookupGeo} from './geo';
 
 const LOCAL = process.env.LOCAL === 'true';
+// Staging deploys set ENV=staging and land in a separate BigQuery dataset
+// so staging traffic never mixes with production analytics.
+const DATASET = process.env.ENV === 'staging' ? 'resourceMap_staging' : 'resourceMap';
 
 interface FeatureClickRow {
   featureId: string | null;
@@ -51,7 +54,7 @@ export const logFeatureClick: HttpFunction = async (req, res) => {
 
   try {
     const bigquery = new BigQuery();
-    await bigquery.dataset('resourceMap').table('featureClicks').insert(row);
+    await bigquery.dataset(DATASET).table('featureClicks').insert(row);
   } catch (err: any) {
     console.error('[log-feature-click] BigQuery insert to "featureClicks" failed:', err?.errors?.[0] || err);
   }

--- a/src/log-geocode.ts
+++ b/src/log-geocode.ts
@@ -3,7 +3,9 @@ import {BigQuery} from '@google-cloud/bigquery';
 import {lookupGeo} from './geo';
 
 const LOCAL = process.env.LOCAL === 'true';
-const DATASET = 'resourceMap';
+// Staging deploys set ENV=staging and land in a separate BigQuery dataset
+// so staging traffic never mixes with production analytics.
+const DATASET = process.env.ENV === 'staging' ? 'resourceMap_staging' : 'resourceMap';
 
 // Truncate coord to a ~110m grid so we never persist a home-precise
 // location for a user's search.


### PR DESCRIPTION
## Summary
Adds an isolated staging environment for the Cloud Functions so we can exercise the privacy refresh end-to-end without touching live analytics.

### `package.json`
- New `deploy:staging` / `deploy:staging:log-feature-click` / `deploy:staging:log-geocode` scripts. Same code, different Cloud Function names (`log-geocode-staging`, `log-feature-click-staging`), each deployed with `ENV=staging`.
- Explicit `--entry-point` on the existing prod scripts for symmetry (was implicit — no behavior change).

### `src/log-geocode.ts`, `src/log-feature-click.ts`
- `DATASET` computed from `process.env.ENV` — writes to `resourceMap_staging` when `ENV=staging`, else `resourceMap`. Live behavior unchanged.

### `schema/2026-07-privacy-refresh.sql`
Two gaps in the live schema turned up while setting up the staging dataset:
- `geocodes.address` is `REQUIRED` in live. New code no longer sends the raw text, so inserts would fail without `ALTER COLUMN address DROP NOT NULL`.
- Neither `geocodes` nor `featureClicks` has `sessionId` or `language` columns. BigQuery streaming silently drops unknown fields, so the current live code has been discarding both since it started logging. Migration now adds them as nullable STRING columns so those fields the code already sends actually land.

Header also updated with the `bq mk` command to create `resourceMap_staging` and a note that the migration runs once per environment.

### Not in this PR
- Live schema is unchanged. The `resourceMap_staging` dataset was set up out-of-band via `bq` CLI (dataset created, tables cloned with `LIKE`, migration applied) so this repo change is code-only.
- The Cloud Functions are not yet deployed. Run `yarn deploy:staging` after merge to create them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)