### PR TITLE
Add teardown:staging to tear down staging Cloud Functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "deploy:staging": "run-s deploy:staging:log-feature-click deploy:staging:log-geocode",
       "deploy:staging:log-feature-click": "gcloud functions deploy log-feature-click-staging --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-feature-click --set-env-vars ENV=staging",
       "deploy:staging:log-geocode": "gcloud functions deploy log-geocode-staging --gen2 --region us-east1 --trigger-http --allow-unauthenticated --runtime nodejs20 --entry-point log-geocode --set-env-vars ENV=staging",
+      "teardown:staging": "gcloud functions delete log-feature-click-staging --gen2 --region us-east1 --quiet; gcloud functions delete log-geocode-staging --gen2 --region us-east1 --quiet",
       "prestart": "npm run build",
       "gcp-build": "npm run build"
    },


### PR DESCRIPTION
## Summary
Single command to tear down both staging Cloud Functions.

Motivation: leaving `log-feature-click-staging` and `log-geocode-staging` deployed risks unexpected invocations (bots, forgotten test tabs) that would still meter through GCP. `yarn teardown:staging` removes both in one shot.

Chained with `;` (not `&&`) so if one function is already gone the other still gets torn down.

## Not affected
- The `resourceMap_staging` BigQuery dataset stays. Cheap to leave, and you may want to inspect staging data even after taking the functions down. Remove manually with `bq rm -r -f -d city-harvest-423311:resourceMap_staging` if you want.
- Production functions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)